### PR TITLE
Update to work with windows-latest and 2022.8.14.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ async function run() {
 		//options.stdio = 'inherit';
 
         //await exec.exec(vsixInst, ['/q', '/a', '/logFile:vsixinst.log', 'SHFBVisualStudioPackage_VS2017And2019.vsix'], { cwd: instFolder});
-        await exec.exec(vsixInst, ['/q', '/a', '/logFile:' + path.join(instFolder, 'vsixinst.log'), 'SHFBVisualStudioPackage_VS2022AndLater.vsix'], { cwd: instFolder});
+        //await exec.exec(vsixInst, ['/q', '/a', '/logFile:' + path.join(instFolder, 'vsixinst.log'), 'SHFBVisualStudioPackage_VS2022AndLater.vsix'], { cwd: instFolder});
 
         //await exec.exec(vsixInst, ['/q', '/a', 'SHFBVisualStudioPackage_VS2017AndLater.vsix'], { cwd: instFolder});
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const core = require('@actions/core'),
       exec = require('@actions/exec'),
       tool = require('@actions/tool-cache'),
       path = require('path'),
-      fs = require('fs');
+      fs = require('fs/promises');
 const child_process = require('child_process');
 
 async function run() {

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const core = require('@actions/core'),
 const child_process = require('child_process');
 
 async function run() {
+    const home = process.env.GITHUB_WORKSPACE;
+    const instFolder = path.join(home, 'InstallResources');
     try {
 
         const version = core.getInput('version');
@@ -12,12 +14,11 @@ async function run() {
 		const vsixInst = '"C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\resources\\app\\ServiceHub\\Services\\Microsoft.VisualStudio.Setup.Service\\VSIXInstaller.exe"';
         const toolUrl = 'https://github.com/EWSoftware/SHFB/releases/download/' + version + '/SHFBInstaller_' + version + '.zip';
         const shfbRoot = 'C:\\Program Files (x86)\\EWSoftware\\Sandcastle Help File Builder\\';
-        const home = process.env.GITHUB_WORKSPACE;
-        const instFolder = path.join(home, 'InstallResources');
 
         // output infos
         console.log('Install SHFB Version: ', version);
         console.log('Download: ', toolUrl);
+	console.log('Install folder: ', instFolder);
 
         // set SHFBROOT env variable
         // needed by msbuild, nuget and VS        
@@ -53,7 +54,7 @@ async function run() {
 		//options.timeout = 4 * 60 * 1000;
 		//options.stdio = 'inherit';
 
-        await exec.exec(vsixInst, ['/q', '/a', '/logFile:vsixinst.log', 'SHFBVisualStudioPackage_VS2017And2019.vsix'], { cwd: instFolder});
+        //await exec.exec(vsixInst, ['/q', '/a', '/logFile:vsixinst.log', 'SHFBVisualStudioPackage_VS2017And2019.vsix'], { cwd: instFolder});
         await exec.exec(vsixInst, ['/q', '/a', '/logFile:vsixinst.log', 'SHFBVisualStudioPackage_VS2017And2022.vsix'], { cwd: instFolder});
 
         //await exec.exec(vsixInst, ['/q', '/a', 'SHFBVisualStudioPackage_VS2017AndLater.vsix'], { cwd: instFolder});
@@ -73,6 +74,13 @@ async function run() {
     }
     catch (error) {
         core.setFailed(error.message);
+        try {
+            const data = await fs.readFile(path.join(instFolder, 'vsixinst.log'), { encoding: 'utf8' });
+	    console.log('error - logfile follows:');
+            console.log(data);
+        } catch (err) {
+            console.log(err);
+        }
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ async function run() {
 		//options.stdio = 'inherit';
 
         //await exec.exec(vsixInst, ['/q', '/a', '/logFile:vsixinst.log', 'SHFBVisualStudioPackage_VS2017And2019.vsix'], { cwd: instFolder});
-        await exec.exec(vsixInst, ['/q', '/a', '/logFile:vsixinst.log', 'SHFBVisualStudioPackage_VS2017And2022.vsix'], { cwd: instFolder});
+        await exec.exec(vsixInst, ['/q', '/a', '/logFile:' + path.join(instFolder, 'vsixinst.log'), 'SHFBVisualStudioPackage_VS2017And2022.vsix'], { cwd: instFolder});
 
         //await exec.exec(vsixInst, ['/q', '/a', 'SHFBVisualStudioPackage_VS2017AndLater.vsix'], { cwd: instFolder});
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,8 @@ async function run() {
 		//options.timeout = 4 * 60 * 1000;
 		//options.stdio = 'inherit';
 
-        await exec.exec(vsixInst, ['/q', '/a', '/logFile:vsixinst.log', 'SHFBVisualStudioPackage_VS2017AndLater.vsix'], { cwd: instFolder});
+        await exec.exec(vsixInst, ['/q', '/a', '/logFile:vsixinst.log', 'SHFBVisualStudioPackage_VS2017And2019.vsix'], { cwd: instFolder});
+        await exec.exec(vsixInst, ['/q', '/a', '/logFile:vsixinst.log', 'SHFBVisualStudioPackage_VS2017And2022.vsix'], { cwd: instFolder});
 
         //await exec.exec(vsixInst, ['/q', '/a', 'SHFBVisualStudioPackage_VS2017AndLater.vsix'], { cwd: instFolder});
 

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ async function run() {
 		//options.stdio = 'inherit';
 
         //await exec.exec(vsixInst, ['/q', '/a', '/logFile:vsixinst.log', 'SHFBVisualStudioPackage_VS2017And2019.vsix'], { cwd: instFolder});
-        await exec.exec(vsixInst, ['/q', '/a', '/logFile:' + path.join(instFolder, 'vsixinst.log'), 'SHFBVisualStudioPackage_VS2017And2022.vsix'], { cwd: instFolder});
+        await exec.exec(vsixInst, ['/q', '/a', '/logFile:' + path.join(instFolder, 'vsixinst.log'), 'SHFBVisualStudioPackage_VS2022AndLater.vsix'], { cwd: instFolder});
 
         //await exec.exec(vsixInst, ['/q', '/a', 'SHFBVisualStudioPackage_VS2017AndLater.vsix'], { cwd: instFolder});
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 const core = require('@actions/core'),
       exec = require('@actions/exec'),
       tool = require('@actions/tool-cache'),
-      path = require('path');
+      path = require('path'),
+      fs = require('fs');
 const child_process = require('child_process');
 
 async function run() {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const core = require('@actions/core'),
       exec = require('@actions/exec'),
       tool = require('@actions/tool-cache'),
       path = require('path'),
-      fs = require('fs/promises');
+      fs = require('fs');
 const child_process = require('child_process');
 
 async function run() {
@@ -76,7 +76,7 @@ async function run() {
     catch (error) {
         core.setFailed(error.message);
         try {
-            const data = await fs.readFile(path.join(instFolder, 'vsixinst.log'), { encoding: 'utf8' });
+            const data = await fs.readFileSync(path.join(instFolder, 'vsixinst.log'), 'utf8');
 	    console.log('error - logfile follows:');
             console.log(data);
         } catch (err) {


### PR DESCRIPTION
Wasn't working because:
1. The file has changed from `...VS2017AndLater.vsix` to `...VS2017And2019.vsix` and `...VS2022AndLater.vsix`
2. VS2022 is used on windows-latest

Probably the default version should change too, readme file, etc.  Maybe add a param for the vsix file to install.